### PR TITLE
Convered main container to fluid

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <script src="eats.js"></script>
 </head>
 <body>
-  <div class="container">
+  <div class="container-fluid">
     <div class="row">
       <div class="col-md-3"></div>
       <div class="col-md-6">


### PR DESCRIPTION
Added bootstrap scaffolding into the codebase with previous commits - all I needed to do was change the container class to `container-fluid` to make everything work nicely on a mobile interface. 

Addresses #1 

![screenshot_2015-11-18_09-33-02](https://cloud.githubusercontent.com/assets/1109418/11251881/6b3edc3c-8dd7-11e5-8372-26fa82bb737f.png)
